### PR TITLE
Patch with our custom requirements

### DIFF
--- a/Dockerfile.pm
+++ b/Dockerfile.pm
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.6-slim
+FROM python:3.6-slim-stretch
 
 COPY . /opt/airflow/
 
@@ -26,13 +26,13 @@ ARG APT_DEPS="$buildDeps libsasl2-dev freetds-bin build-essential default-libmys
 
 WORKDIR /opt/airflow
 RUN set -x \
-    && apt-get update \
-    && if [ -n "${APT_DEPS}" ]; then apt-get install -y $APT_DEPS; fi \
+    && apt update \
+    && if [ -n "${APT_DEPS}" ]; then apt install -y $APT_DEPS; fi \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install --no-cache-dir ${PYTHON_DEPS}; fi \
     && SLUGIFY_USES_TEXT_UNIDECODE=yes pip install --no-cache-dir -e .[$AIRFLOW_DEPS] \
-    && apt-get purge --auto-remove -yqq $buildDeps \
-    && apt-get autoremove -yqq --purge \
-    && apt-get clean
+    && apt purge --auto-remove -yqq $buildDeps \
+    && apt autoremove -yqq --purge \
+    && apt clean
 
 WORKDIR $AIRFLOW_HOME
 RUN mkdir -p $AIRFLOW_HOME

--- a/Dockerfile.pm
+++ b/Dockerfile.pm
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.6-slim
+
+COPY . /opt/airflow/
+
+ARG AIRFLOW_HOME=/usr/local/airflow
+ARG AIRFLOW_DEPS="async,crypto,devel,gcp_api,kubernetes,ldap,password,postgres,s3,google_auth"
+ARG PYTHON_DEPS=""
+ARG buildDeps="freetds-dev libkrb5-dev libsasl2-dev libssl-dev libffi-dev libpq-dev git"
+ARG APT_DEPS="$buildDeps libsasl2-dev freetds-bin build-essential default-libmysqlclient-dev apt-utils curl rsync netcat locales"
+
+WORKDIR /opt/airflow
+RUN set -x \
+    && apt-get update \
+    && if [ -n "${APT_DEPS}" ]; then apt-get install -y $APT_DEPS; fi \
+    && if [ -n "${PYTHON_DEPS}" ]; then pip install --no-cache-dir ${PYTHON_DEPS}; fi \
+    && SLUGIFY_USES_TEXT_UNIDECODE=yes pip install --no-cache-dir -e .[$AIRFLOW_DEPS] \
+    && apt-get purge --auto-remove -yqq $buildDeps \
+    && apt-get autoremove -yqq --purge \
+    && apt-get clean
+
+WORKDIR $AIRFLOW_HOME
+RUN mkdir -p $AIRFLOW_HOME
+CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+# ----------------
+#    Docker
+# ----------------
+IMAGE ?= us.gcr.io/datafall-prod/airflow
+TAG ?=  20190829
+
+prod-build:
+	docker build -f Dockerfile.pm -t $(IMAGE):$(TAG) .
+
+prod-push:
+	docker push $(IMAGE):$(TAG)
+
+test-build:
+	docker build -f Dockerfile.pm -t $(IMAGE):$(TAG)-test-image .
+
+test-push:
+    docker push $(IMAGE):$(TAG)-test-image
+
+prod-upgrade: prod-build prod-push
+
+test-image: test-build test-push
+
+pull:
+	docker pull $(IMAGE):$(TAG)
+
+clean-image:
+	docker rmi $(IMAGE):$(TAG) -f

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ----------------
 #    Docker
 # ----------------
-IMAGE ?= gcr.io/datafall-prod/airflow
+IMAGE ?= gcr.io/pm-registry/airflow
 TAG ?=  20190829
 
 prod-build:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ----------------
 #    Docker
 # ----------------
-IMAGE ?= us.gcr.io/datafall-prod/airflow
+IMAGE ?= gcr.io/datafall-prod/airflow
 TAG ?=  20190829
 
 prod-build:

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -171,8 +171,6 @@ class KubeConfig:
         self.worker_run_as_user = self._get_security_context_val('run_as_user')
         self.worker_fs_group = self._get_security_context_val('fs_group')
 
-        self.k8s_release = conf.get(self.kubernetes_section, 'k8s_release')
-
         # NOTE: `git_repo` and `git_branch` must be specified together as a pair
         # The http URL of the git repository to clone from
         self.git_repo = conf.get(self.kubernetes_section, 'git_repo')

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -416,7 +416,6 @@ class WorkerConfiguration(LoggingMixin):
                                self.kube_config.kube_image_pull_policy),
             cmds=airflow_command,
             labels=self._get_labels(kube_executor_config.labels, {
-                'release': self.kube_config.k8s_release,
                 'airflow-worker': worker_uuid,
                 'dag_id': dag_id,
                 'task_id': task_id,

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -22,6 +22,7 @@ from airflow.configuration import conf
 from airflow.contrib.kubernetes.pod import Pod, Resources
 from airflow.contrib.kubernetes.secret import Secret
 from airflow.utils.log.logging_mixin import LoggingMixin
+from collections import defaultdict
 
 
 class WorkerConfiguration(LoggingMixin):
@@ -164,6 +165,12 @@ class WorkerConfiguration(LoggingMixin):
 
         for env_var_name, env_var_val in six.iteritems(self.kube_config.kube_env_vars):
             env[env_var_name] = env_var_val
+
+        for env_var_name, env_var_val in six.iteritems(self.kube_config.kubernetes_environment):
+            env_var_key = env_var_name.split('_')[1]
+            if env_var_key in env.keys():
+                raise Exception('{} already exists in env vars'.format(env_var_key))
+            env[env_var_key] = env_var_val
 
         env["AIRFLOW__CORE__EXECUTOR"] = "LocalExecutor"
 
@@ -328,6 +335,49 @@ class WorkerConfiguration(LoggingMixin):
                 'readOnly': True
             }
 
+        if len(self.kube_config.kubernetes_configmaps) > 0:
+            mount_dic = defaultdict(dict)
+            for key, value in self.kube_config.kubernetes_configmaps.items():
+                prefix, suffix = key.split('_')
+                mount_dic[prefix][suffix] = value
+            for prefix in mount_dic:
+                configmap_volume_name = f'{prefix}-configmap'
+                config_path = mount_dic[prefix]['path']
+                configmap_name = mount_dic[prefix]['configmap']
+                volumes[configmap_volume_name] = {
+                    'name': configmap_volume_name,
+                    'configMap': {
+                        'name': configmap_name
+                    }
+                }
+                volume_mounts[configmap_volume_name] = {
+                    'name': configmap_volume_name,
+                    'mountPath': config_path,
+                    'readOnly': True
+                }
+
+        if len(self.kube_config.kubernetes_mounts) > 0:
+            mount_dic = defaultdict(dict)
+            for key, value in self.kube_config.kubernetes_mounts.items():
+                prefix, suffix = key.split('_')
+                mount_dic[prefix][suffix] = value
+            for prefix in mount_dic:
+                credential_volume_name = f'{prefix}-secret'
+                config_path = mount_dic[prefix]['path']
+                secret_name = mount_dic[prefix]['secret']
+                volumes[credential_volume_name] = {
+                    'name': credential_volume_name,
+                    'secret': {
+                        'secretName': secret_name
+                    }
+                }
+                volume_mounts[credential_volume_name] = {
+                    'name': credential_volume_name,
+                    'mountPath': config_path,
+                    'readOnly': True
+                }
+
+
         return volumes, volume_mounts
 
     def generate_dag_volume_mount_path(self):
@@ -343,10 +393,14 @@ class WorkerConfiguration(LoggingMixin):
         volumes_dict, volume_mounts_dict = self._get_volumes_and_mounts()
         worker_init_container_spec = self._get_init_containers()
         resources = Resources(
-            request_memory=kube_executor_config.request_memory,
-            request_cpu=kube_executor_config.request_cpu,
-            limit_memory=kube_executor_config.limit_memory,
-            limit_cpu=kube_executor_config.limit_cpu,
+            request_memory=(kube_executor_config.request_memory or
+                            self.kube_config.kube_worker_resources["request_memory"]),
+            request_cpu=(kube_executor_config.request_cpu or
+                         self.kube_config.kube_worker_resources["request_cpu"]),
+            limit_memory=(kube_executor_config.limit_memory or
+                          self.kube_config.kube_worker_resources["limit_memory"]),
+            limit_cpu=(kube_executor_config.limit_cpu or
+                       self.kube_config.kube_worker_resources["limit_cpu"]),
             limit_gpu=kube_executor_config.limit_gpu
         )
         gcp_sa_key = kube_executor_config.gcp_service_account_key
@@ -368,6 +422,7 @@ class WorkerConfiguration(LoggingMixin):
                                self.kube_config.kube_image_pull_policy),
             cmds=airflow_command,
             labels=self._get_labels(kube_executor_config.labels, {
+                'release': self.kube_config.k8s_release,
                 'airflow-worker': worker_uuid,
                 'dag_id': dag_id,
                 'task_id': task_id,

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -166,12 +166,6 @@ class WorkerConfiguration(LoggingMixin):
         for env_var_name, env_var_val in six.iteritems(self.kube_config.kube_env_vars):
             env[env_var_name] = env_var_val
 
-        for env_var_name, env_var_val in six.iteritems(self.kube_config.kubernetes_environment):
-            env_var_key = env_var_name.split('_')[1]
-            if env_var_key in env.keys():
-                raise Exception('{} already exists in env vars'.format(env_var_key))
-            env[env_var_key] = env_var_val
-
         env["AIRFLOW__CORE__EXECUTOR"] = "LocalExecutor"
 
         if self.kube_config.airflow_configmap:


### PR DESCRIPTION
# Our Custom Requirements
### _AKA: Why We Need a Fork_

- `Dockerfile.pm`
  - This is what we use to run airflow in all our containers deployed in datafall
- `Makefile`
  - Contains commands to build our airflow image and push to google container registry
- `kubernetes_executor.py`
  - `self.kubernetes_mounts` brings in our secrets mounts [seen here](https://github.com/postmates/datafall/blob/master/deployment/airflow-configmap.libsonnet#L201-L203)
  - `self.kubernetes_configmaps` brings in our custom configmaps [seen here](https://github.com/postmates/datafall/blob/master/deployment/airflow-configmap.libsonnet#L205-L207)
  - `self.kube_worker_resources` adds [defaults for all worker pods](https://github.com/postmates/datafall/blob/master/deployment/airflow-configmap.libsonnet#L195-L199) when they are not specified in the Kubernetes Executor Config dictionary passed to an individual task
  - We also make adjustments to the naming conventions for worker pods to avoid generated pod names that are prohibitively long. This has caused issues in other areas of our k8s cluster.
- `worker_configuration.py`
  - Here we read in the changes made above to the KubeConfig: the configmap mount, secrets mount, and default memory/cpu requests.